### PR TITLE
Updates

### DIFF
--- a/1.3/Patches/RemoveClutter.xml
+++ b/1.3/Patches/RemoveClutter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/GenStepDef[defName="AncientConcreteBarrier" or defName="AncientLamppost" or defName="ScatterRoadDebris" or defName="ScatterCaveDebris" or defName="AncientUtilityBuilding" or defName="MechanoidRemains" or defName="AncientTurret" or defName="AncientMechs" or defName="AncientLandingPad" or defName="AncientFences" or defName="AncientJunkClusters"]/order</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/GenStepDef[defName="AncientPipelineSection"]</xpath>
+			<value>
+				<order>0</order>
+			</value>
+	</Operation>
+
+</Patch>

--- a/1.3/Patches/ReplaceCommConsole.xml
+++ b/1.3/Patches/ReplaceCommConsole.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
-	<Operation Class="PatchOperationSequence">
+	<Operation Class="PatchOperationFindMod">
+	<mods>
+      <li>Tribal Signal Fire (Continued)</li>
+    </mods>
+	<nomatch Class="PatchOperationSequence">
 		<operations>
 
 			<li Class="PatchOperationReplace">
@@ -117,6 +120,7 @@
 
 
 		</operations>
+	</nomatch>
 	</Operation>
 
 </Patch>


### PR DESCRIPTION
Don't replace CommConsole if Tribal Signal Fire mod is detected

Remove all ancient and mechanoid clutter from spawning on mapgen.